### PR TITLE
check-for-update: use '!' after shell redirection to force overwrite even if noclobber option is set

### DIFF
--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -53,7 +53,7 @@ _zgen-check-for-updates() {
       echo "Updating plugins"
     fi
     zgen update
-    date +%s > ~/${ZGEN_PLUGIN_RECEIPT_F}
+    date +%s >! ~/${ZGEN_PLUGIN_RECEIPT_F}
   fi
 
   if [ ${last_system} -gt ${system_seconds} ]; then
@@ -62,7 +62,7 @@ _zgen-check-for-updates() {
       echo "Updating zgen..."
     fi
     zgen selfupdate
-    date +%s > ~/${ZGEN_SYSTEM_RECEIPT_F}
+    date +%s >! ~/${ZGEN_SYSTEM_RECEIPT_F}
   fi
 }
 


### PR DESCRIPTION
In my setup, i have the noclobber shell option set which prevents destructive shell redirection.

The '!' after > forces it to overwrite, even if noclobber is set.

Without this, every time I launch a shell it attempts to update.
