### PR TITLE
prevent multiple shell instances to try updating at the same time

### DIFF
--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -69,7 +69,7 @@ _zgen-check-for-updates() {
 zmodload zsh/system
 lockfile=~/.zgen_autoupdate_lock
 touch $lockfile
-if which zsystem > /dev/null && zsystem flock -t 1 $lockfile; then
+if which zsystem &> /dev/null && zsystem flock -t 1 $lockfile; then
   _zgen-check-for-updates
   rm $lockfile
 fi

--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -66,4 +66,10 @@ _zgen-check-for-updates() {
   fi
 }
 
-_zgen-check-for-updates
+zmodload zsh/system
+lockfile=~/.zgen_autoupdate_lock
+touch $lockfile
+if zsystem flock -t 1 $lockfile; then
+  _zgen-check-for-updates
+  rm $lockfile
+fi

--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -69,7 +69,7 @@ _zgen-check-for-updates() {
 zmodload zsh/system
 lockfile=~/.zgen_autoupdate_lock
 touch $lockfile
-if zsystem flock -t 1 $lockfile; then
+if which zsystem > /dev/null && zsystem flock -t 1 $lockfile; then
   _zgen-check-for-updates
   rm $lockfile
 fi


### PR DESCRIPTION
In my case, when I log into my computer, several terminals are started and my tmux sessions with several shell windows are restored automatically.
Every week, autoupdate-zgen tried to perform the update on every single shell, which of course caused some problems (luckily, nothing very serious, as git seems to be rather good with avoiding multiple pulls running at the same time).
However, it's annoying, because you see a lot of error messages (failed git pull).

This commit only performs the update check & actual update in a single shell instance.
