### PR TITLE
Remove lockfile with native rm command (fixes #6)

### DIFF
--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -71,5 +71,5 @@ lockfile=~/.zgen_autoupdate_lock
 touch $lockfile
 if ! which zsystem &> /dev/null || zsystem flock -t 1 $lockfile; then
   _zgen-check-for-updates
-  rm $lockfile
+  command rm -f $lockfile
 fi


### PR DESCRIPTION
This patch removes the confirmation when rm is aliased to `rm -i` or any other non-default behavior of an aliased `rm` (e.g. send removed files to a trash directory).
