### PR TITLE
Respect $ZGEN_DIR if set

### DIFF
--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -39,7 +39,9 @@ _zgen-check-for-updates() {
       # respect to the home directory but $ZGEN_DIR is an absolute path,
       # $ZGEN_{SYSTEM|PLUGIN}_RECEIPT_F is set to $ZGEN_DIR (if it is defined)
       # with the $HOME directory as the prefix removed
-      ZGEN_SYSTEM_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_system_update"
+      # (That's what the "${${ZGEN_DIR}#${HOME}}" syntax does: it removes the
+      # "$HOME" prefix from "$ZGEN_DIR")
+      ZGEN_SYSTEM_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_system_lastupdate"
     else
       ZGEN_SYSTEM_RECEIPT_F='.zgen_system_lastupdate'
     fi
@@ -47,7 +49,7 @@ _zgen-check-for-updates() {
 
   if [ -z "${ZGEN_PLUGIN_RECEIPT_F}" ]; then
     if [ -n "${ZGEN_DIR}" ]; then
-      ZGEN_PLUGIN_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_plugin_update"
+      ZGEN_PLUGIN_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_plugin_lastupdate"
     else
       ZGEN_PLUGIN_RECEIPT_F='.zgen_plugin_lastupdate'
     fi

--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -34,11 +34,23 @@ _zgen-check-for-updates() {
   fi
 
   if [ -z "${ZGEN_SYSTEM_RECEIPT_F}" ]; then
-    ZGEN_SYSTEM_RECEIPT_F='.zgen_system_lastupdate'
+    if [ -n "${ZGEN_DIR}" ]; then
+      # Since the $ZGEN_{SYSTEM|PLUGIN}_RECEIPT_F variables are with
+      # respect to the home directory but $ZGEN_DIR is an absolute path,
+      # $ZGEN_{SYSTEM|PLUGIN}_RECEIPT_F is set to $ZGEN_DIR (if it is defined)
+      # with the $HOME directory as the prefix removed
+      ZGEN_SYSTEM_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_system_update"
+    else
+      ZGEN_SYSTEM_RECEIPT_F='.zgen_system_lastupdate'
+    fi
   fi
 
   if [ -z "${ZGEN_PLUGIN_RECEIPT_F}" ]; then
-    ZGEN_PLUGIN_RECEIPT_F='.zgen_plugin_lastupdate'
+    if [ -n "${ZGEN_DIR}" ]; then
+      ZGEN_PLUGIN_RECEIPT_F="${${ZGEN_DIR}#${HOME}}/.zgen_plugin_update"
+    else
+      ZGEN_PLUGIN_RECEIPT_F='.zgen_plugin_lastupdate'
+    fi
   fi
 
   local day_seconds=$(expr 24 \* 60 \* 60)
@@ -74,7 +86,7 @@ _zgen-check-for-updates() {
 #
 # Use ls and awk instead of stat because stat has incompatible arguments
 # on linux, macOS and FreeBSD.
-local zgen_owner=$(ls -ld $HOME/.zgen | awk '{print $3}')
+local zgen_owner=$(ls -ld ${ZGEN_DIR:-$HOME/.zgen} | awk '{print $3}')
 if [[ "$zgen_owner" == "$USER" ]]; then
   zmodload zsh/system
   lockfile=~/.zgen_autoupdate_lock


### PR DESCRIPTION
zgen has an environment variable called `$ZGEN_DIR` that allows you to change the location of the zgen directory (which is `~/.zgen` by default). This allows people who want to minimize the amount of files in their home directory (or who just want to reorganize their home directory) by, say, moving zgen-affiliated files into the directory where other Zsh-affiliated files (`.zshenv`, `.zshrc`, etc.) are. Currently, the `autoupdate-zgen.plugin.zsh` script doesn't respect the value of `$ZGEN_DIR`, and so it creates the `.zgen_system_lastupdate` and `.zgen_plugin_lastupdate` files in the home directory. Fortunately, this can easily be changed by setting `$ZGEN_SYSTEM_RECEIPT_F` and `$ZGEN_PLUGIN_RECEIPT_F` _before_ running the `autoupdate-zgen.plugin.zsh` script.

This was fine, except now that #15 runs `ls -ld $HOME/.zgen` on line 77, if you've changed the location of the zgen directory from its default, every time you start a new Zsh session you'll get an `ls: cannot access '<home directory>/.zgen': No such file or directory` error.

This PR is a 2-in-1: by refactoring this script to respect the value of `$ZGEN_DIR` (if that variable is set), it makes it so that users do not have to manually set `$ZGEN_SYSTEM_RECEIPT_F` and `$ZGEN_PLUGIN_RECEIPT_F` if they are fine with the `.zgen_system_lastupdate` and `.zgen_plugin_lastupdate` files being placed in `$ZGEN_DIR` (obviously if they still want it somewhere else they'll still have to set those variables). Additionally, it fixes that bug so that `ls` will not fail if someone moved their `$ZGEN_DIR` outside of `~/.zgen`.

I also noticed that a `~/.zgen_autoupdate_lock` file gets created, but it looks like it gets deleted soon after, so I don't think we need to worry about that respecting `$ZGEN_DIR`?