### PR TITLE
Clean up lockfile usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 [![Code Climate](https://codeclimate.com/github/unixorn/autoupdate-zgen/badges/gpa.svg)](https://codeclimate.com/github/unixorn/autoupdate-zgen)
 [![Issue Count](https://codeclimate.com/github/unixorn/autoupdate-zgen/badges/issue_count.svg)](https://codeclimate.com/github/unixorn/autoupdate-zgen)
 
-[zgen](https://github.com/tarjoilija/zgen) doesn't do automatic updates like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh). **autoupdate-zgen** sets up easy automatic updating, both of zgen and the bundles loaded in your configuration.
+[zgen](https://github.com/tarjoilija/zgen) and [zgenom](https://github.com/jandamm/zgenom) both don't include an automatic update function like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) does.
 
-Activate with `zgen load unixorn/autoupdate-zgen` and regenerate your `init.zsh` file.
+**autoupdate-zgen** sets up easy automatic updating, both of zgenom or zgen and the plugins loaded in your configuration.
+
+Activate with `zgenom load unixorn/autoupdate-zgen` or `zgen load unixorn/autoupdate-zgen` and regenerate your `init.zsh` file.
 
 ## Configuration
 

--- a/autoupdate-zgen.plugin.zsh
+++ b/autoupdate-zgen.plugin.zsh
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 Joe Block <jpb@unixorn.net>
+# Copyright 2014-2021 Joe Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,9 +92,10 @@ local zgen_owner=$(ls -ld ${ZGEN_DIR:-$HOME/.zgen} | awk '{print $3}')
 if [[ "$zgen_owner" == "$USER" ]]; then
   zmodload zsh/system
   lockfile=~/.zgen_autoupdate_lock
-  touch $lockfile
-  if ! which zsystem &> /dev/null || zsystem flock -t 1 $lockfile; then
+  touch "$lockfile"
+  if ! which zsystem &> /dev/null || zsystem flock -t 1 "$lockfile"; then
     _zgen-check-for-updates
-    command rm -f $lockfile
+    command rm -f "$lockfile"
   fi
+  unset lockfile
 fi


### PR DESCRIPTION
- Make sure we double-quote `$lockfile` so we won't break if there are spaces in the path to `$ZGEN_DIR`
- Add zgenom references to README.md